### PR TITLE
Publish odom twist in child_frame_id

### DIFF
--- a/src/segway_rmp_node.cpp
+++ b/src/segway_rmp_node.cpp
@@ -266,7 +266,8 @@ public:
         float yaw_displacement = 
             (ss.integrated_turn_position - this->initial_integrated_turn_position) * 
             degrees_to_radians * this->angular_odom_scale;
-        float yaw_rate = ss.yaw_rate * degrees_to_radians;
+        // reverse yaw axis to match base_link frame fixed axis
+        float yaw_rate = -(ss.yaw_rate * degrees_to_radians); 
         
         // Integrate the displacements over time
         // If not the first odometry calculate the delta in displacements
@@ -276,17 +277,17 @@ public:
             float delta_forward_displacement = 
                 forward_displacement - this->last_forward_displacement;
             double delta_time = (current_time-this->last_time).toSec();
-            // Update accumulated odometries and calculate the x and y components 
-            // of velocity
+
+            // Update accumulated odometries and calculate the x velocity
             this->odometry_w = yaw_displacement;
             float delta_odometry_x = 
                 delta_forward_displacement * std::cos(this->odometry_w);
-            vel_x = delta_odometry_x / delta_time;
             this->odometry_x += delta_odometry_x;
             float delta_odometry_y = 
                 delta_forward_displacement * std::sin(this->odometry_w);
-            vel_y = delta_odometry_y / delta_time;
             this->odometry_y += delta_odometry_y;
+
+            vel_x = delta_forward_displacement / delta_time;
         } else {
             this->first_odometry = false;
         }


### PR DESCRIPTION
This node currently publishes the `twist` component in the world frame, instead of the body frame. This differs from the [`nav_msg/Odometry` message description](http://docs.ros.org/jade/api/nav_msgs/html/msg/Odometry.html), which says:

> The twist in this message should be specified in the coordinate frame given by the `child_frame_id`

This pull request fixes this issue by making `segway_rmp` publish twists in the `child_frame_id`. It also fixes a bug that caused yaw rate to be reported as z-down. We had to make both of these changes to successfully use the output of `segway_rmp` as an input to the `robot_localization` package (see https://github.com/cra-ros-pkg/robot_localization/issues/221).
