### PR TITLE
Fixed message dependency error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(catkin REQUIRED
   COMPONENTS
     geometry_msgs
     message_generation
-    message_runtime
     nav_msgs
     roscpp
     serial
@@ -34,6 +33,7 @@ catkin_package(
   DEPENDS libsegwayrmp
   CATKIN_DEPENDS
     geometry_msgs
+    message_runtime
     nav_msgs
     roscpp
     serial
@@ -44,6 +44,8 @@ catkin_package(
 add_executable(segway_rmp_node src/segway_rmp_node.cpp)
 
 message("libsegwayrmp_LIBRARIES: ${libsegwayrmp_LIBRARIES}")
+
+add_dependencies(segway_rmp_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(segway_rmp_node
   ${Boost_LIBRARIES}


### PR DESCRIPTION
Due to an omission, when building this package is build, the executable is occasionally built before the messages (specifically the SegwayStatusStamped message). This pull request adds the appropriate dependencies to the executable.